### PR TITLE
Added new attribute "canBeSelectedWithNoChildren"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 bower_components
 test.html
 .tmp
+.DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ selection model. If you'd rather not have these checkboxes use
 </div>
 ```
 
+If you don't want a default functionality, when a parent node can't be selected alone without selection of any of it's own children, then use
+`can-be-selected-with-no-children="true"`:
+
+```html
+<div ng-controller="MyCtrl as fancy">
+  <div ivh-treeview="fancy.bag"
+    can-be-selected-with-no-children="true">
+</div>
+```
+
 There's also a provider if you'd like to change the global defaults:
 
 ```javascript
@@ -89,7 +99,8 @@ app.config(function(ivhTreeviewOptionsProvider) {
     validate: true,
     twistieExpandedTpl: '(-)',
     twistieCollapsedTpl: '(+)',
-    twistieLeafTpl: 'o'
+    twistieLeafTpl: 'o',
+    canBeSelectedWithNoChildren: false
   });
 });
 ```

--- a/src/scripts/directives/ivh-treeview.js
+++ b/src/scripts/directives/ivh-treeview.js
@@ -42,6 +42,7 @@ angular.module('ivh.treeview').directive('ivhTreeview', ['ivhTreeviewMgr', funct
       useCheckboxes: '=ivhTreeviewUseCheckboxes',
       validate: '=ivhTreeviewValidate',
       visibleAttribute: '=ivhTreeviewVisibleAttribute',
+      canBeSelectedWithNoChildren: '=canBeSelectedWithNoChildren',
 
       // Generic options object
       userOptions: '=ivhTreeviewOptions',
@@ -72,7 +73,8 @@ angular.module('ivh.treeview').directive('ivhTreeview', ['ivhTreeviewMgr', funct
         'twistieLeafTpl',
         'useCheckboxes',
         'validate',
-        'visibleAttribute'
+        'visibleAttribute',
+        'canBeSelectedWithNoChildren'
       ], function(attr) {
         if(ng.isDefined($scope[attr])) {
           localOpts[attr] = $scope[attr];
@@ -123,6 +125,10 @@ angular.module('ivh.treeview').directive('ivhTreeview', ['ivhTreeviewMgr', funct
 
       ctrl.useCheckboxes = function() {
         return localOpts.useCheckboxes;
+      };
+
+      ctrl.canBeSelectedWithNoChildren = function() {
+          return localOpts.canBeSelectedWithNoChildren;
       };
 
       ctrl.select = function(node, isSelected) {

--- a/src/scripts/services/ivh-treeview-mgr.js
+++ b/src/scripts/services/ivh-treeview-mgr.js
@@ -126,7 +126,9 @@ angular.module('ivh.treeview')
             makeDeselected.bind(opts);
 
           ivhTreeviewBfs(n, opts, cb);
-          ng.forEach(p, validateParent.bind(opts));
+          if(!opts.canBeSelectedWithNoChildren) {
+              ng.forEach(p, validateParent.bind(opts));
+          }
         }
 
         return proceed;

--- a/src/scripts/services/ivh-treeview-options.js
+++ b/src/scripts/services/ivh-treeview-options.js
@@ -50,6 +50,14 @@ angular.module('ivh.treeview').provider('ivhTreeviewOptions', function() {
     useCheckboxes: true,
 
     /**
+     * Whether or not is the parent node automatically selected even if all of it's children are unselected
+     *
+     * If `true` then the parent node can be selected, when none of it's own children is selected
+     * or when at least one of it's children is selected, then the parent node isn't automatically selected
+     */
+    canBeSelectedWithNoChildren: false,
+
+    /**
      * Whether or not directive should validate treestore on startup
      *
      * Must opt-in.


### PR DESCRIPTION
for the detection, whether or not can be the parent node automatically selected even if all of it's children are unselected

![snimka obrazovky 2015-04-10 o 15 10 09](https://cloud.githubusercontent.com/assets/5699580/7088404/9b6bc3ea-df93-11e4-9afd-0191ab4cab8e.png)

![snimka obrazovky 2015-04-10 o 15 11 58](https://cloud.githubusercontent.com/assets/5699580/7088427/c84542f6-df93-11e4-88f8-3ab4a6b40ac0.png)

