### PR TITLE
Add validateParents and recursiveSelection as options

### DIFF
--- a/src/scripts/directives/ivh-treeview.js
+++ b/src/scripts/directives/ivh-treeview.js
@@ -43,6 +43,8 @@ angular.module('ivh.treeview').directive('ivhTreeview', ['ivhTreeviewMgr', funct
       twistieLeafTpl: '=ivhTreeviewTwistieLeafTpl',
       useCheckboxes: '=ivhTreeviewUseCheckboxes',
       validate: '=ivhTreeviewValidate',
+      validateParents: '=ivhTreeviewValidateParents',
+      recursiveSelection: '=ivhTreeviewRecursiveSelection',
       visibleAttribute: '=ivhTreeviewVisibleAttribute',
 
       // Generic options object
@@ -77,6 +79,8 @@ angular.module('ivh.treeview').directive('ivhTreeview', ['ivhTreeviewMgr', funct
         'twistieLeafTpl',
         'useCheckboxes',
         'validate',
+        'validateParents',
+        'recursiveSelection',
         'visibleAttribute'
       ], function(attr) {
         if(ng.isDefined($scope[attr])) {
@@ -255,8 +259,8 @@ angular.module('ivh.treeview').directive('ivhTreeview', ['ivhTreeviewMgr', funct
        * @param {Object} node The node to select or deselect
        * @param {Boolean} isSelected Defaults to `true`
        */
-      trvw.select = function(node, isSelected) {
-        ivhTreeviewMgr.select($scope.root, node, localOpts, isSelected);
+      trvw.select = function(node, isSelected, eventOpts) {
+        ivhTreeviewMgr.select($scope.root, node, ng.extend({}, localOpts, eventOpts), isSelected);
         trvw.onCbChange(node, isSelected);
       };
 

--- a/src/scripts/services/ivh-treeview-mgr.js
+++ b/src/scripts/services/ivh-treeview-mgr.js
@@ -129,8 +129,14 @@ angular.module('ivh.treeview')
             makeSelected.bind(opts) :
             makeDeselected.bind(opts);
 
-          ivhTreeviewBfs(n, opts, cb);
-          ng.forEach(p, validateParent.bind(opts));
+          if(opts.recursiveSelection) {
+            ivhTreeviewBfs(n, opts, cb);
+          } else {
+            cb(n);
+          }
+          if(opts.validateParents) {
+            ng.forEach(p, validateParent.bind(opts));
+          }
         }
 
         return proceed;

--- a/src/scripts/services/ivh-treeview-options.js
+++ b/src/scripts/services/ivh-treeview-options.js
@@ -55,6 +55,16 @@ angular.module('ivh.treeview').provider('ivhTreeviewOptions', function() {
     validate: true,
 
     /**
+     * Whether or not directive should validate parent state on change
+     */
+    validateParents: true,
+
+    /**
+     * Whether or not directive should select children recursively when a parent is selected
+     */
+    recursiveSelection: true,
+
+    /**
      * Collection item attribute to track intermediate states
      */
     indeterminateAttribute: '__ivhTreeviewIndeterminate',


### PR DESCRIPTION
Add validateParents and recursiveSelection as options

Allow options overriding on an event basis (e.g. recursive selection made possible programmatically if disabled globally)

Fix eslint errors

Fix #124