### PR TITLE
feature: Allow for checkboxes to not propagate state to children

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ app.controller('MyCtrl', function(ivhTreeviewOptions) {
   // opts.childrenAttribute === 'children'
   // opts.selectedAttribute === 'selected'
   // opts.useCheckboxes === true
+  // opts.disableCheckboxSelectionPropagation === false
   // opts.expandToDepth === 0
   // opts.indeterminateAttribute === '__ivhTreeviewIndeterminate'
   // opts.expandedAttribute === '__ivhTreeviewExpanded'

--- a/src/scripts/directives/ivh-treeview-checkbox-helper.js
+++ b/src/scripts/directives/ivh-treeview-checkbox-helper.js
@@ -30,6 +30,12 @@ angular.module('ivh.treeview').directive('ivhTreeviewCheckboxHelper', [function(
       // Enforce consistent behavior across browsers by making indeterminate
       // checkboxes become checked when clicked/selected using spacebar
       scope.resolveIndeterminateClick = function() {
+
+        //intermediate state is not handled when CheckBoxes state propagation is disabled
+        if (opts.disableCheckboxSelectionPropagation) {
+          return;
+        }
+
         if(node[indeterminateAttr]) {
           trvw.select(node, true);
         }
@@ -40,10 +46,12 @@ angular.module('ivh.treeview').directive('ivhTreeviewCheckboxHelper', [function(
         scope.isSelected = newVal;
       });
 
-      // Update the checkbox when the node's indeterminate status changes
-      scope.$watch('node.' + indeterminateAttr, function(newVal, oldVal) {
-        element.find('input').prop('indeterminate', newVal);
-      });
+      if (!opts.disableCheckboxSelectionPropagation) {
+        // Update the checkbox when the node's indeterminate status changes
+        scope.$watch('node.' + indeterminateAttr, function(newVal, oldVal) {
+          element.find('input').prop('indeterminate', newVal);
+        });
+      }
     },
     template: [
       '<input type="checkbox"',

--- a/src/scripts/directives/ivh-treeview.js
+++ b/src/scripts/directives/ivh-treeview.js
@@ -29,6 +29,7 @@ angular.module('ivh.treeview').directive('ivhTreeview', ['ivhTreeviewMgr', funct
       // Specific config options
       childrenAttribute: '=ivhTreeviewChildrenAttribute',
       defaultSelectedState: '=ivhTreeviewDefaultSelectedState',
+      disableCheckboxSelectionPropagation: '=ivhTreeviewDisableCheckboxSelectionPropagation',
       expandToDepth: '=ivhTreeviewExpandToDepth',
       idAttribute: '=ivhTreeviewIdAttribute',
       indeterminateAttribute: '=ivhTreeviewIndeterminateAttribute',
@@ -65,6 +66,7 @@ angular.module('ivh.treeview').directive('ivhTreeview', ['ivhTreeviewMgr', funct
       ng.forEach([
         'childrenAttribute',
         'defaultSelectedState',
+        'disableCheckboxSelectionPropagation',
         'expandToDepth',
         'idAttribute',
         'indeterminateAttribute',

--- a/src/scripts/services/ivh-treeview-mgr.js
+++ b/src/scripts/services/ivh-treeview-mgr.js
@@ -129,8 +129,12 @@ angular.module('ivh.treeview')
             makeSelected.bind(opts) :
             makeDeselected.bind(opts);
 
-          ivhTreeviewBfs(n, opts, cb);
-          ng.forEach(p, validateParent.bind(opts));
+          if (opts.disableCheckboxSelectionPropagation) {
+            cb(n);
+          } else {
+            ivhTreeviewBfs(n, opts, cb);
+            ng.forEach(p, validateParent.bind(opts));
+          }
         }
 
         return proceed;

--- a/src/scripts/services/ivh-treeview-options.js
+++ b/src/scripts/services/ivh-treeview-options.js
@@ -55,6 +55,14 @@ angular.module('ivh.treeview').provider('ivhTreeviewOptions', [
     useCheckboxes: true,
 
     /**
+     * If set to true the checkboxes are independent on each other (no state
+     * propagation to children and revalidation of parents' states).
+     * If you set to true, you should set also `validate` property to `false`
+     * and avoid explicit calling of `ivhTreeviewMgr.validate()`.
+     */
+    disableCheckboxSelectionPropagation: false,
+
+    /**
      * Whether or not directive should validate treestore on startup
      */
     validate: true,


### PR DESCRIPTION
There is new option `disableCheckboxSelectionPropagation` that id set to `true` disables propagation of state of checkboxes to children and switches off validation of parents state. Thus the checkboxes are independent on each other and selection of checkbox on any level is relevant only to it's item.

Closes #195